### PR TITLE
Typescript section problem

### DIFF
--- a/pomTypescriptExample3.4.1/nightwatch/page-objects/Google/GoogleResultsPage.ts
+++ b/pomTypescriptExample3.4.1/nightwatch/page-objects/Google/GoogleResultsPage.ts
@@ -7,6 +7,16 @@ const googleResultsPage = {
   elements: {
     searchResultsDiv: '#rso',
   },
+  sections: {
+    someSection: {
+      selector: "#someSectionSelector",
+      commands: [{
+        clickOnSomeThing(this: EnhancedPageObject) {
+          this.click('@searchResultsDiv');
+        }
+      }]
+    }
+  }
 } satisfies PageObjectModel;
 
 export default googleResultsPage;
@@ -14,5 +24,6 @@ export default googleResultsPage;
 export interface GoogleResultsPage
   extends EnhancedPageObject<
     typeof googleResultsPageCommands,
-    typeof googleResultsPage.elements
+    typeof googleResultsPage.elements,
+    typeof googleResultsPage.sections
   > {}

--- a/pomTypescriptExample3.4.1/nightwatch/tests/google.ts
+++ b/pomTypescriptExample3.4.1/nightwatch/tests/google.ts
@@ -15,6 +15,8 @@ const googleTest: NightwatchTests = {
     browser.page.Google.GoogleResultsPage()
       .waitForElementVisible('@searchResultsDiv')
       .assert.textContains('@searchResultsDiv', 'Nightwatch.js');
+    // how to resolve this? 
+    browser.page.Google.GoogleResultsPage().section.someSection.clickOnSomeThing();
   },
   after: (browser: NightwatchAPI) => {
     browser.end();


### PR DESCRIPTION
Hey, I love your repository and I am glad that you have these examples here. Can you please check this code? I am not sure how to type section or what change I should do. 

When you write `sections` in `PageObjectModel`, it works properly and it give you correct types etc, but when you want to use custom command from section, it throws error

```js
The 'this' context of type 'EnhancedSectionInstance<Required<{ clickOnSomeThing: (this: EnhancedPageObject) => void; }>, Required<unknown>, Required<unknown>, Required<unknown>>' is not assignable to method's 'this' of type 'EnhancedPageObject'.
  Type 'EnhancedPageObjectSections<Required<{ clickOnSomeThing: (this: EnhancedPageObject) => void; }>, Required<unknown>, Required<unknown>, Required<unknown>> & ... 4 more ... & Pick<...>' is missing the following properties from type 'SharedCommands': closeWindow, fullscreenWindow, minimizeWindow, openNewWindow, and 7 more.ts(2684)
(property) someSection: EnhancedSectionInstance<Required<{
    clickOnSomeThing: (this: EnhancedPageObject) => void;
}>, Required<unknown>, Required<unknown>, Required<unknown>>
```

Can you check it and add example with section and section's custom commands? 🙏 Thanks!